### PR TITLE
Slow down page and UI animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,10 +149,10 @@ function App ()
     const ballRig = root.querySelector( '.ball-rig' )
     const cursorDot = root.querySelector( '.cursor-dot' )
     const cursorRing = root.querySelector( '.cursor-ring' )
+    const pointerGlow = root.querySelector( '.pointer-glow' )
     let pointerFrame = 0
     let pointerX = 0
     let pointerY = 0
-    let lastPointerPaint = 0
     let ballLayerIsPromoted = false
     const hasFinePointer = window.matchMedia( '(hover: hover) and (pointer: fine)' ).matches
     const moveCursorDotX = hasFinePointer
@@ -167,6 +167,21 @@ function App ()
     const moveCursorRingY = hasFinePointer
       ? gsap.quickTo( cursorRing, 'y', { duration: 0.12 } )
       : null
+    const movePointerGlowX = hasFinePointer
+      ? gsap.quickTo( pointerGlow, 'x', { duration: 0.14, ease: 'power2.out' } )
+      : null
+    const movePointerGlowY = hasFinePointer
+      ? gsap.quickTo( pointerGlow, 'y', { duration: 0.14, ease: 'power2.out' } )
+      : null
+
+    // Start the glow in the same centered position as the old CSS gradient.
+    if ( hasFinePointer )
+    {
+      gsap.set( pointerGlow, {
+        x: window.innerWidth * 0.5,
+        y: window.innerHeight * 0.5,
+      } )
+    }
 
     const getPageIndex = ( progress ) =>
       Math.min(
@@ -198,20 +213,15 @@ function App ()
 
       if ( pointerFrame ) return
 
-      pointerFrame = window.requestAnimationFrame( ( timestamp ) =>
+      pointerFrame = window.requestAnimationFrame( () =>
       {
         moveCursorDotX( pointerX )
         moveCursorDotY( pointerY )
         moveCursorRingX( pointerX )
         moveCursorRingY( pointerY )
-
-        // Repaint the large pointer-reactive gradients at 30fps instead of every frame.
-        if ( timestamp - lastPointerPaint >= 33 )
-        {
-          root.style.setProperty( '--pointer-x', `${( pointerX / window.innerWidth ) * 100}%` )
-          root.style.setProperty( '--pointer-y', `${( pointerY / window.innerHeight ) * 100}%` )
-          lastPointerPaint = timestamp
-        }
+        // Move one isolated layer; this avoids repainting the full stage on hover.
+        movePointerGlowX( pointerX )
+        movePointerGlowY( pointerY )
 
         pointerFrame = 0
       } )
@@ -592,7 +602,7 @@ function App ()
     {
       if ( pointerFrame ) window.cancelAnimationFrame( pointerFrame )
       if ( hasFinePointer ) window.removeEventListener( 'pointermove', movePointer )
-      gsap.killTweensOf( [ cursorDot, cursorRing ] )
+      gsap.killTweensOf( [ cursorDot, cursorRing, pointerGlow ] )
       ballRig.style.removeProperty( 'will-change' )
       animationContext.revert()
     }
@@ -602,13 +612,17 @@ function App ()
   const replay = () => goToPage( 0 )
 
   return (
-    <main className="experience" ref={ rootRef }>
+    <main
+      className={ `experience${activePage === 3 ? ' is-projects-active' : ''}` }
+      ref={ rootRef }
+    >
       <section className="story" ref={ storyRef } aria-label="Interactive 8 Ball Studio introduction">
         <div className="story-pages" aria-hidden="true">
           { STORY_PAGES.map( ( page ) => <div className="story-page" id={ page.id } key={ page.id } /> ) }
         </div>
 
         <div className="stage">
+          <div className="pointer-glow" aria-hidden="true" />
           <div className="camera-grid" aria-hidden="true" />
           <div className="ambient ambient-one" aria-hidden="true" />
           <div className="ambient ambient-two" aria-hidden="true" />

--- a/src/hooks/useStoryPager.js
+++ b/src/hooks/useStoryPager.js
@@ -1,20 +1,20 @@
 import { useCallback, useEffect, useRef } from 'react'
 import gsap from 'gsap'
 
-// Adjacent pages use the full cinematic transition duration.
-export const PAGE_TRANSITION_SECONDS = 0.3
+// Double the page tween so each navigation transition has more visual weight.
+export const PAGE_TRANSITION_SECONDS = 0.6
 
-// Long pagination jumps stay readable but finish faster than adjacent moves.
-export const MIN_PAGE_TRANSITION_SECONDS = 0.3
+// Keep long jumps from becoming faster than the slower adjacent-page motion.
+export const MIN_PAGE_TRANSITION_SECONDS = 0.6
 
-// Remove this much time for every additional page crossed.
-export const PAGE_DISTANCE_SPEEDUP_SECONDS = 0.18
+// Scale the distance adjustment with the slower base transition.
+export const PAGE_DISTANCE_SPEEDUP_SECONDS = 0.36
 
 // Small trackpad events accumulate until they represent one intentional gesture.
 export const WHEEL_THRESHOLD_PX = 12
 
-// Inertial wheel events must stop for this long before another page can start.
-export const WHEEL_RELEASE_MS = 90
+// Keep only a short one-frame guard after a transition to prevent wheel inertia from double-firing.
+export const WHEEL_RELEASE_MS = 24
 
 // A mobile swipe must travel this far before it changes a page.
 export const TOUCH_THRESHOLD_PX = 52
@@ -183,24 +183,32 @@ export function useStoryPager ( {
     let touchIdentifier = null
     let touchStartY = null
     let touchLastY = null
+    let storyTop = 0
+    let storyHeight = 0
 
-    const isStoryActive = () =>
+    const refreshStoryMetrics = () =>
     {
       const bounds = story.getBoundingClientRect()
 
+      storyTop = window.scrollY + bounds.top
+      storyHeight = story.offsetHeight
+    }
+
+    const isStoryActive = () =>
+    {
+      const storyEnd = storyTop + storyHeight - window.innerHeight
+
       return (
-        bounds.top <= 2 &&
-        bounds.bottom >= window.innerHeight - 2
+        window.scrollY >= storyTop - 2 &&
+        window.scrollY <= storyEnd + 2
       )
     }
 
     const getNearestPageIndex = () =>
     {
-      const bounds = story.getBoundingClientRect()
-      const storyTop = window.scrollY + bounds.top
       const scrollRange = Math.max(
         1,
-        story.offsetHeight - window.innerHeight,
+        storyHeight - window.innerHeight,
       )
 
       const rawProgress = ( window.scrollY - storyTop ) / scrollRange
@@ -417,6 +425,7 @@ export function useStoryPager ( {
 
       resizeTimer = window.setTimeout( () =>
       {
+        refreshStoryMetrics()
         const pageIndex = targetPageRef.current
         const targetY = getTargetY( pageIndex )
 
@@ -440,6 +449,7 @@ export function useStoryPager ( {
     }
 
     html.classList.add( 'story-pager-enabled' )
+    refreshStoryMetrics()
 
     // Reloading in the middle of the document should land on a stable story page.
     const initialPageIndex = getNearestPageIndex()
@@ -458,7 +468,8 @@ export function useStoryPager ( {
       } )
     }
 
-    window.addEventListener( 'wheel', handleWheel, { passive: false } )
+    // Limit the non-passive listener to the story so unrelated page scrolling stays compositor-friendly.
+    story.addEventListener( 'wheel', handleWheel, { passive: false } )
     window.addEventListener( 'keydown', handleKeyDown )
     window.addEventListener( 'resize', settleAfterResize )
 
@@ -479,7 +490,7 @@ export function useStoryPager ( {
     {
       html.classList.remove( 'story-pager-enabled' )
 
-      window.removeEventListener( 'wheel', handleWheel )
+      story.removeEventListener( 'wheel', handleWheel )
       window.removeEventListener( 'keydown', handleKeyDown )
       window.removeEventListener( 'resize', settleAfterResize )
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,8 +11,6 @@
   --felt: #0b5b3b;
   --ink: #070908;
   --paper: #f2f1e9;
-  --pointer-x: 50%;
-  --pointer-y: 50%;
 }
 
 * {
@@ -103,7 +101,6 @@ a:focus-visible {
   overflow: hidden;
   perspective: 1450px;
   background:
-    radial-gradient(circle at var(--pointer-x) var(--pointer-y), rgba(48, 145, 96, 0.28), transparent 31%),
     linear-gradient(128deg, #0d3f2c 0%, #0b2e21 38%, #071a12 100%);
   cursor: none;
   touch-action: pan-y;
@@ -112,6 +109,21 @@ a:focus-visible {
 /* Single-touch movement is routed through useStoryPager to stop momentum skipping. */
 .story-pager-enabled .stage {
   touch-action: none;
+}
+
+/* A movable layer preserves the pointer glow without invalidating the whole stage. */
+.pointer-glow {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  left: 0;
+  width: min(58vw, 920px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(48, 145, 96, 0.28) 0, rgba(48, 145, 96, 0.12) 28%, transparent 68%);
+  transform: translate(-50%, -50%);
+  will-change: transform;
 }
 
 .stage::before {
@@ -227,7 +239,6 @@ a:focus-visible {
   border-radius: clamp(14px, 1.55vw, 25px);
   background:
     radial-gradient(circle at 42% 45%, rgba(70, 180, 124, 0.31), transparent 31%),
-    radial-gradient(circle at var(--pointer-x) var(--pointer-y), rgba(176, 255, 195, 0.12), transparent 28%),
     linear-gradient(126deg, #116344 0%, #0b4d34 52%, #073822 100%);
   box-shadow:
     inset 0 0 54px rgba(0, 0, 0, 0.52),
@@ -582,7 +593,6 @@ a:focus-visible {
     radial-gradient(circle at 74% 20%, rgba(183, 217, 91, 0.06), transparent 22%),
     #070908;
   visibility: hidden;
-  will-change: transform, opacity;
 }
 
 .final-content {
@@ -667,7 +677,6 @@ a:focus-visible {
     radial-gradient(circle at 86% 16%, rgba(183, 217, 91, 0.07), transparent 22%),
     linear-gradient(135deg, #07110d, #070908 64%);
   visibility: hidden;
-  will-change: transform, opacity;
 }
 
 .projects-content {
@@ -717,8 +726,15 @@ a:focus-visible {
 .projects-track {
   display: flex;
   width: max-content;
+  will-change: auto;
+  animation: projects-marquee 52s linear infinite;
+  animation-play-state: paused;
+}
+
+/* Animate and promote the marquee only while its page is visible. */
+.experience.is-projects-active .projects-track {
+  animation-play-state: running;
   will-change: transform;
-  animation: projects-marquee 26s linear infinite;
 }
 
 .projects-group {
@@ -788,7 +804,6 @@ a:focus-visible {
     radial-gradient(circle at 12% 82%, rgba(183, 217, 91, 0.07), transparent 26%),
     linear-gradient(135deg, #09140f, #070908 62%);
   visibility: hidden;
-  will-change: transform, opacity;
 }
 
 .contact-content {
@@ -842,7 +857,7 @@ a:focus-visible {
   gap: clamp(14px, 1.6vw, 22px);
   grid-template-columns: auto 1fr;
   text-decoration: none;
-  transition: background 150ms, color 150ms;
+  transition: background 300ms, color 300ms;
 }
 
 .contact-item + .contact-item {
@@ -857,7 +872,7 @@ a:focus-visible {
   border: 1px solid rgba(183, 217, 91, 0.52);
   border-radius: 50%;
   color: var(--acid);
-  transition: background 300ms, color 300ms;
+  transition: background 600ms, color 600ms;
 }
 
 a.contact-item:hover,
@@ -971,7 +986,7 @@ a.contact-item:focus-visible .contact-icon {
   border-radius: 50%;
   background: rgba(7, 17, 13, 0.38);
   content: '';
-  transition: background 300ms, border-color 300ms, transform 300ms;
+  transition: background 600ms, border-color 600ms, transform 600ms;
 }
 
 .page-dot span {
@@ -989,7 +1004,7 @@ a.contact-item:focus-visible .contact-icon {
   pointer-events: none;
   text-transform: uppercase;
   transform: translateX(5px);
-  transition: opacity 200ms, transform 200ms;
+  transition: opacity 400ms, transform 400ms;
   white-space: nowrap;
 }
 
@@ -1110,7 +1125,7 @@ a.contact-item:focus-visible .contact-icon {
   }
 
   .projects-track {
-    animation-duration: 22s;
+    animation-duration: 44s;
   }
 
   .projects-group {
@@ -1155,7 +1170,8 @@ a.contact-item:focus-visible .contact-icon {
   }
 
   .cursor-dot,
-  .cursor-ring {
+  .cursor-ring,
+  .pointer-glow {
     display: none;
   }
 
@@ -1299,7 +1315,8 @@ a.contact-item:focus-visible .contact-icon {
 
   .cursor-dot,
   .cursor-ring,
-  .scroll-prompt {
+  .scroll-prompt,
+  .pointer-glow {
     display: none;
   }
 }
@@ -1310,7 +1327,8 @@ a.contact-item:focus-visible .contact-icon {
   }
 
   .cursor-dot,
-  .cursor-ring {
+  .cursor-ring,
+  .pointer-glow {
     display: none;
   }
 


### PR DESCRIPTION
## What changed
- Isolate the cursor glow on its own transform layer so pointer movement does not repaint the full stage.
- Cache story geometry and scope the non-passive wheel listener to the story container.
- Run the Projects marquee only while Projects is active.
- Reduce the wheel-release guard to 24ms so scrolling resumes quickly after transitions.
- Slow page navigation and UI motion by 2x while keeping the short wheel guard.

## Why
The trace showed scroll and hover work invalidating too much of the scene and leaving a noticeable blocker after transitions.

## Impact
Scrolling and cursor movement do less main-thread/layout work. Transitions retain visual weight, and wheel input resumes quickly after the animation completes.

## Checks
Not run. Project instructions explicitly prohibit automated tests or verification runs.