### PR TITLE
Draft 2: finish break-to-Studio handoff from one soft swipe

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,10 @@ const CUE_PROGRESS_EPSILON = 0.0005
 // Damp input during the pool-table sequence so the heavy ball cannot race ahead of the scroll.
 const DRAFT2_HANDOFF_DURATION = 0.46
 const DRAFT2_TRANSITION_READY_STORY_PROGRESS = DRAFT2_TIMING_CONTRACT.transitionReady / 3
+// Start the Studio page indicator just after its title fade begins, so it never leads a hidden title.
+const DRAFT2_STUDIO_PAGE_BOUNDARY_EPSILON = 0.0005
+const DRAFT2_STUDIO_PAGE_START_PROGRESS =
+  DRAFT2_TRANSITION_READY_STORY_PROGRESS + DRAFT2_STUDIO_PAGE_BOUNDARY_EPSILON
 const INTRO_SCROLL_WEIGHT = 0.72
 // Give Draft 1 enough fixed time to show the strike, spread, and full cut into Studio.
 const CINEMATIC_BREAK_TRANSITION_DURATION = 1.8
@@ -45,7 +49,7 @@ const easeCinematicBreakTransition = ( progress ) =>
   progress * progress * ( 3 - 2 * progress )
 const getStudioStartProgress = ( draftId ) =>
   draftId === 'webgl'
-    ? DRAFT2_TRANSITION_READY_STORY_PROGRESS
+    ? DRAFT2_STUDIO_PAGE_START_PROGRESS
     : STORY_PAGES[ 1 ].startProgress
 
 const getDraft2ExitProgress = ( progress ) =>
@@ -261,6 +265,7 @@ function App ()
     let pointerY = 0
     let ballLayerIsPromoted = false
     let cueGateState = 'armed'
+    let draft2HandoffTargetScroll = null
     const hasFinePointer = window.matchMedia( '(hover: hover) and (pointer: fine)' ).matches
     const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches
 
@@ -347,6 +352,11 @@ function App ()
         const currentProgress = getStoryProgress( currentScroll, metrics )
         const candidateProgress = getStoryProgress( candidateTarget, metrics )
 
+        if ( effectiveDeltaY < 0 || currentProgress >= studioProgress - CUE_PROGRESS_EPSILON )
+        {
+          draft2HandoffTargetScroll = null
+        }
+
         if (
           effectiveDeltaY > 0 &&
           currentProgress < studioProgress - CUE_PROGRESS_EPSILON &&
@@ -354,6 +364,17 @@ function App ()
         )
         {
           const studioScroll = Math.round( metrics.top + metrics.range * studioProgress )
+
+          // One continuous gesture can emit many packets; memo the assist target so
+          // later packets do not restart its easing or create a second-swipe gate.
+          if ( draft2HandoffTargetScroll === studioScroll )
+          {
+            if ( isTouch ) return consumeCueInput( event )
+            return true
+          }
+          // Stop browser-native touch scrolling from racing the programmatic handoff.
+          if ( isTouch && event.cancelable ) event.preventDefault()
+          draft2HandoffTargetScroll = studioScroll
 
           // The qualifying gesture already crossed the rack-spread boundary. Let its
           // remaining momentum finish the short handoff without locking reverse input.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,12 +36,15 @@ const CUE_READY_PROGRESS_BY_DRAFT = Object.freeze( {
 } )
 const CUE_PROGRESS_EPSILON = 0.0005
 // Damp input during the pool-table sequence so the heavy ball cannot race ahead of the scroll.
-const DRAFT2_HANDOFF_DURATION = 0.46
+// Keep the final camera cut short so a soft swipe reaches the full Studio page quickly.
+const DRAFT2_HANDOFF_DURATION = 0.2
 const DRAFT2_TRANSITION_READY_STORY_PROGRESS = DRAFT2_TIMING_CONTRACT.transitionReady / 3
 // Start the Studio page indicator just after its title fade begins, so it never leads a hidden title.
 const DRAFT2_STUDIO_PAGE_BOUNDARY_EPSILON = 0.0005
 const DRAFT2_STUDIO_PAGE_START_PROGRESS =
   DRAFT2_TRANSITION_READY_STORY_PROGRESS + DRAFT2_STUDIO_PAGE_BOUNDARY_EPSILON
+// Cut the shared 8-ball before its old pocket-drop path starts; Draft 1 keeps its original animation.
+const DRAFT2_POCKET_CUT_STORY_PROGRESS = ( DRAFT2_TIMING_CONTRACT.transitionReady - 0.04 ) / 3
 const INTRO_SCROLL_WEIGHT = 0.72
 // Give Draft 1 enough fixed time to show the strike, spread, and full cut into Studio.
 const CINEMATIC_BREAK_TRANSITION_DURATION = 1.8
@@ -823,6 +826,11 @@ function App ()
           const syncDraft2Handoff = ( progress ) =>
           {
             if ( activeDraftRef.current !== 'webgl' ) return
+
+            const cutPocketDrop = progress >= DRAFT2_POCKET_CUT_STORY_PROGRESS
+            // Draft 2 skips the old 8-ball drop and iris hold; Draft 1 remains untouched.
+            gsap.set( '.ball-rig', { autoAlpha: cutPocketDrop ? 0 : 1 } )
+            gsap.set( '.pocket-iris', { autoAlpha: cutPocketDrop ? 0 : 1 } )
 
             const exitProgress = getDraft2ExitProgress( progress )
             const titleOffset = ( 1 - exitProgress ) * 115

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import {
   CINEMATIC_CUE_READY_PROGRESS,
   CINEMATIC_EXIT_END,
   CINEMATIC_EXIT_START,
+  DRAFT2_TIMING_CONTRACT,
 } from './drafts/poolBreakPhysics'
 // One V4 asset supplies both the header brand mark and animated 8-ball surface.
 import brandLogo from './assets/8BALL-V4.jpg'
@@ -32,10 +33,11 @@ const STORY_PAGES = [
 // Each cue draft stops its first gesture at the point where that scene finishes aiming.
 const CUE_READY_PROGRESS_BY_DRAFT = Object.freeze( {
   cinematic: CINEMATIC_CUE_READY_PROGRESS / 3,
-  webgl: 0.52 / 3,
 } )
 const CUE_PROGRESS_EPSILON = 0.0005
 // Damp input during the pool-table sequence so the heavy ball cannot race ahead of the scroll.
+const DRAFT2_HANDOFF_DURATION = 0.46
+const DRAFT2_TRANSITION_READY_STORY_PROGRESS = DRAFT2_TIMING_CONTRACT.transitionReady / 3
 const INTRO_SCROLL_WEIGHT = 0.72
 // Give Draft 1 enough fixed time to show the strike, spread, and full cut into Studio.
 const CINEMATIC_BREAK_TRANSITION_DURATION = 1.8
@@ -293,7 +295,9 @@ function App ()
 
       if ( !( isWheel || isTouch ) ) return true
 
-      if ( storyProgressRef.current * 3 < CINEMATIC_EXIT_END )
+      const isDraft2 = activeDraftRef.current === 'webgl'
+      const introWeightLimit = isDraft2 ? DRAFT2_TIMING_CONTRACT.transitionReady : CINEMATIC_EXIT_END
+      if ( storyProgressRef.current * 3 < introWeightLimit )
       {
         // Reduce wheel and touch travel only while the 8-ball sequence is on screen.
         scrollInput.deltaY *= INTRO_SCROLL_WEIGHT
@@ -303,7 +307,7 @@ function App ()
       const cueReadyProgress = CUE_READY_PROGRESS_BY_DRAFT[ activeDraftRef.current ]
 
       // Draft 3 has no cue sequence, so it keeps the original continuous scroll.
-      if ( cueReadyProgress === undefined )
+      if ( cueReadyProgress === undefined && !isDraft2 )
       {
         cueGateState = 'armed'
         return true
@@ -326,6 +330,36 @@ function App ()
         : deltaY
 
       if ( effectiveDeltaY === 0 ) return true
+      if ( isDraft2 )
+      {
+        const studioProgress = STORY_PAGES[ 1 ].targetProgress
+        const currentScroll = lenis.scroll
+        const candidateTarget = lenis.targetScroll + effectiveDeltaY
+        const currentProgress = getStoryProgress( currentScroll, metrics )
+        const candidateProgress = getStoryProgress( candidateTarget, metrics )
+
+        if (
+          effectiveDeltaY > 0 &&
+          currentProgress < studioProgress - CUE_PROGRESS_EPSILON &&
+          candidateProgress >= DRAFT2_TRANSITION_READY_STORY_PROGRESS
+        )
+        {
+          const studioScroll = Math.round( metrics.top + metrics.range * studioProgress )
+
+          // The qualifying gesture already crossed the rack-spread boundary. Let its
+          // remaining momentum finish the short handoff without locking reverse input.
+          lenis.scrollTo( studioScroll, {
+            duration: prefersReducedMotion ? 0 : DRAFT2_HANDOFF_DURATION,
+            easing: easeCinematicBreakTransition,
+            immediate: prefersReducedMotion,
+            force: true,
+            programmatic: true,
+          } )
+          return false
+        }
+
+        return true
+      }
 
       const checkpointScroll = metrics.top + metrics.range * cueReadyProgress
       const currentScroll = lenis.scroll

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,15 @@ const INTRO_SCROLL_WEIGHT = 0.72
 const CINEMATIC_BREAK_TRANSITION_DURATION = 1.8
 const easeCinematicBreakTransition = ( progress ) =>
   progress * progress * ( 3 - 2 * progress )
+const getStudioStartProgress = ( draftId ) =>
+  draftId === 'webgl'
+    ? DRAFT2_TRANSITION_READY_STORY_PROGRESS
+    : STORY_PAGES[ 1 ].startProgress
+
+const getDraft2ExitProgress = ( progress ) =>
+  Math.min( 1, Math.max( 0, ( progress - DRAFT2_TRANSITION_READY_STORY_PROGRESS ) /
+    ( ( DRAFT2_TIMING_CONTRACT.exitEnd - DRAFT2_TIMING_CONTRACT.transitionReady ) / 3 ) ) )
+
 
 const DRAFT_IDS = [ 'cinematic', 'webgl', 'original' ]
 
@@ -587,11 +596,14 @@ function App ()
     }
 
     const getPageIndex = ( progress ) =>
-      STORY_PAGES.reduce(
+    {
+      const studioStartProgress = getStudioStartProgress( activeDraftRef.current )
+      return STORY_PAGES.reduce(
         ( currentIndex, page, index ) =>
-          progress >= page.startProgress ? index : currentIndex,
+          progress >= ( index === 1 ? studioStartProgress : page.startProgress ) ? index : currentIndex,
         0,
       )
+    }
 
     const updateActivePage = ( progress ) =>
     {
@@ -650,8 +662,9 @@ function App ()
         {
           // Reduced-motion scenes use the same entry points as their active pagination dots.
           updateDraftProgress( progress )
-          const showIntro = progress < STORY_PAGES[ 1 ].startProgress
-          const showStudio = progress >= STORY_PAGES[ 1 ].startProgress && progress < STORY_PAGES[ 2 ].startProgress
+          const studioStartProgress = getStudioStartProgress( activeDraftRef.current )
+          const showIntro = progress < studioStartProgress
+          const showStudio = progress >= studioStartProgress && progress < STORY_PAGES[ 2 ].startProgress
           const showProjects = progress >= STORY_PAGES[ 2 ].startProgress && progress < STORY_PAGES[ 3 ].startProgress
           const showContact = progress >= STORY_PAGES[ 3 ].startProgress
           const showEndScreen = showStudio || showProjects || showContact
@@ -786,6 +799,23 @@ function App ()
           gsap.set( '.contact-title-line > span', { y: 0, yPercent: 115 } )
           gsap.set( '.contact-item', { y: 20, autoAlpha: 0 } )
 
+          const syncDraft2Handoff = ( progress ) =>
+          {
+            if ( activeDraftRef.current !== 'webgl' ) return
+
+            const exitProgress = getDraft2ExitProgress( progress )
+            const titleOffset = ( 1 - exitProgress ) * 115
+            gsap.set( '.scene-interface', { autoAlpha: 1 - exitProgress } )
+            gsap.set( '.title-screen', { autoAlpha: exitProgress } )
+            gsap.set( '.final-title-line > span', {
+              autoAlpha: exitProgress,
+              yPercent: titleOffset,
+            } )
+            gsap.set( '.final-meta', {
+              autoAlpha: exitProgress,
+              y: ( 1 - exitProgress ) * 20,
+            } )
+          }
           const timeline = gsap.timeline( {
             scrollTrigger: {
               trigger: storyRef.current,
@@ -798,11 +828,13 @@ function App ()
               {
                 updateDraftProgress( progress )
                 setBallLayerPromotion( progress > 0.001 && progress < 0.999 )
+                syncDraft2Handoff( progress )
                 updateActivePage( progress )
               },
               onRefresh: ( { progress } ) =>
               {
                 updateDraftProgress( progress )
+                syncDraft2Handoff( progress )
                 updateActivePage( progress )
               },
             },

--- a/src/drafts/WebglPoolDraft.jsx
+++ b/src/drafts/WebglPoolDraft.jsx
@@ -13,9 +13,8 @@ import brandLogo from '../assets/8BALL-V4.jpg'
 RectAreaLightUniformsLib.init()
 import {
   getBreakSimulation,
-  sampleBreakState,
-  CINEMATIC_EXIT_START,
-  CINEMATIC_EXIT_END,
+  sampleDraft2BreakState,
+  DRAFT2_TIMING_CONTRACT,
 } from './poolBreakPhysics'
 
 const clamp = ( value, min = 0, max = 1 ) => Math.min( max, Math.max( min, value ) )
@@ -1257,20 +1256,20 @@ export function WebglPoolDraft ( {
     {
       if ( failed || !world ) return
 
-      const state = sampleBreakState( progress, simulation )
+      const state = sampleDraft2BreakState( progress, simulation )
 
       if ( phaseLabel )
       {
         phaseLabel.textContent = progress <= 0.04
           ? 'TABLE  /  SET'
-          : progress < CINEMATIC_EXIT_START
+          : progress < DRAFT2_TIMING_CONTRACT.exitStart
             ? 'BREAK  /  RUN'
-            : progress < CINEMATIC_EXIT_END
+            : progress < DRAFT2_TIMING_CONTRACT.exitEnd
               ? 'POCKET  /  CLEAR'
               : 'STUDIO  /  CUT'
       }
 
-      const exitProgress = clamp( ( progress - CINEMATIC_EXIT_START ) / ( CINEMATIC_EXIT_END - CINEMATIC_EXIT_START ) )
+      const exitProgress = clamp( ( progress - DRAFT2_TIMING_CONTRACT.exitStart ) / ( DRAFT2_TIMING_CONTRACT.exitEnd - DRAFT2_TIMING_CONTRACT.exitStart ) )
 
       // Sync physical ball meshes and contact shadows to deterministic physics state
       state.balls.forEach( ( ball, index ) =>
@@ -1306,7 +1305,7 @@ export function WebglPoolDraft ( {
 
       // Camera starts locked behind 8-ball and smoothly tracks forward down-table on first swipe as ball rolls and breaks
       const portraitMix = clamp( ( 0.86 - world.camera.aspect ) / 0.36 )
-      const trackProgress = clamp( progress / CINEMATIC_EXIT_START )
+      const trackProgress = clamp( progress / DRAFT2_TIMING_CONTRACT.transitionReady )
       const trackEase = trackProgress * trackProgress * ( 3 - 2 * trackProgress )
 
       const camY = THREE.MathUtils.lerp( 0.78 + portraitMix * 0.45, 1.35 + portraitMix * 0.55, trackEase )

--- a/src/drafts/poolBreakPhysics.js
+++ b/src/drafts/poolBreakPhysics.js
@@ -9,14 +9,14 @@ const CONTACT_EPSILON = 2e-6
 // Hold the break on screen long enough for the slower, heavier spread to read before the cut.
 export const CINEMATIC_EXIT_START = 0.76
 export const CINEMATIC_EXIT_END = 0.90
-// Draft 2 compresses only the scroll allocation after impact; the simulation frames stay unchanged.
+// Draft 2 keeps the readable spread, then cuts directly into the next page before a pocket-drop hold.
 export const DRAFT2_TIMING_CONTRACT = Object.freeze( {
   approachEnd: 0.52,
   impact: 0.52,
   transitionReady: 0.68,
   exitStart: 0.68,
-  exitEnd: 0.84,
-  studioHandoff: 0.84,
+  exitEnd: 0.74,
+  studioHandoff: 0.74,
 } )
 const LEGACY_BREAK_TIMING = Object.freeze( {
   approachEnd: 0.52,

--- a/src/drafts/poolBreakPhysics.js
+++ b/src/drafts/poolBreakPhysics.js
@@ -9,6 +9,23 @@ const CONTACT_EPSILON = 2e-6
 // Hold the break on screen long enough for the slower, heavier spread to read before the cut.
 export const CINEMATIC_EXIT_START = 0.76
 export const CINEMATIC_EXIT_END = 0.90
+// Draft 2 compresses only the scroll allocation after impact; the simulation frames stay unchanged.
+export const DRAFT2_TIMING_CONTRACT = Object.freeze( {
+  approachEnd: 0.52,
+  impact: 0.52,
+  transitionReady: 0.68,
+  exitStart: 0.68,
+  exitEnd: 0.84,
+  studioHandoff: 0.84,
+} )
+const LEGACY_BREAK_TIMING = Object.freeze( {
+  approachEnd: 0.52,
+  impact: 0.52,
+  transitionReady: CINEMATIC_EXIT_START,
+  exitStart: CINEMATIC_EXIT_START,
+  exitEnd: CINEMATIC_EXIT_END,
+  studioHandoff: CINEMATIC_EXIT_END,
+} )
 // Draft 1 uses the first gesture to park the cue behind a stationary 8-ball.
 export const CINEMATIC_CUE_READY_PROGRESS = 0.24
 // Browsers round scroll positions to pixels, so this dead zone keeps swipe one fully still.
@@ -1007,17 +1024,17 @@ const slerpQuaternion = ( first, second, progress ) =>
   return result
 }
 
-// Sample the same frozen frames in either scroll direction; no live integration occurs here.
-export function sampleBreakState ( suppliedProgress, simulation = getBreakSimulation() )
+// Sample the same frozen frames in either scroll direction under one timing contract.
+const sampleBreakStateWithTiming = ( suppliedProgress, simulation, timing ) =>
 {
   const progress = clamp( suppliedProgress )
   const { config, frames, initial, milestones } = simulation
   const radius = config.ball.radius
 
-  if ( progress <= 0.52 )
+  if ( progress <= timing.approachEnd )
   {
     // Accelerate into the rack so the striker carries visible momentum before impact.
-    const approachProgress = ( progress / 0.52 ) ** 2
+    const approachProgress = ( progress / timing.approachEnd ) ** 2
     const x = lerp( initial.strikerStart.x, initial.strikerImpact.x, approachProgress )
     const z = lerp( initial.strikerStart.z, initial.strikerImpact.z, approachProgress )
     const distance = magnitude2( x - initial.strikerStart.x, z - initial.strikerStart.z )
@@ -1048,8 +1065,9 @@ export function sampleBreakState ( suppliedProgress, simulation = getBreakSimula
 
   const milestoneFrame = milestones.transitionReadyFrame
   // Freeze on the requested wide scatter so later simulation frames cannot create a dead scroll tail.
-  const sampledProgress = Math.min( progress, CINEMATIC_EXIT_START )
-  const rawBreakProgress = ( sampledProgress - 0.52 ) / 0.38
+  const sampledProgress = Math.min( progress, timing.transitionReady )
+  const rawBreakProgress = ( sampledProgress - timing.impact ) /
+    ( timing.transitionReady - timing.impact )
   // Ease through the first impulse so the rack compresses before the full scatter develops.
   const breakProgress = smoothstep( rawBreakProgress )
   const exactFrame = breakProgress * milestoneFrame
@@ -1078,16 +1096,28 @@ export function sampleBreakState ( suppliedProgress, simulation = getBreakSimula
     }
   } )
   const opacity = clamp(
-    1 - ( progress - CINEMATIC_EXIT_START ) /
-      ( CINEMATIC_EXIT_END - CINEMATIC_EXIT_START ),
+    1 - ( progress - timing.exitStart ) /
+      ( timing.exitEnd - timing.exitStart ),
   )
 
   return freezeDeep( {
     balls,
     opacity,
-    phase: progress <= CINEMATIC_EXIT_START ? 'break' : 'exit',
+    phase: progress <= timing.exitStart ? 'break' : 'exit',
   } )
 }
+// Draft 1 and existing consumers retain the original cinematic timing.
+export function sampleBreakState ( suppliedProgress, simulation = getBreakSimulation() )
+{
+  return sampleBreakStateWithTiming( suppliedProgress, simulation, LEGACY_BREAK_TIMING )
+}
+
+// Draft 2 uses the shorter post-impact contract without changing Draft 1's frames or fade.
+export function sampleDraft2BreakState ( suppliedProgress, simulation = getBreakSimulation() )
+{
+  return sampleBreakStateWithTiming( suppliedProgress, simulation, DRAFT2_TIMING_CONTRACT )
+}
+
 
 // Hold Draft 1 still through its aim checkpoint, then fit the full break into swipe two.
 export function sampleCinematicBreakState (

--- a/src/drafts/poolBreakPhysics.test.js
+++ b/src/drafts/poolBreakPhysics.test.js
@@ -2,7 +2,9 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   CINEMATIC_CUE_READY_PROGRESS,
+  DRAFT2_TIMING_CONTRACT,
   getBreakSimulation,
+  sampleDraft2BreakState,
   sampleCinematicBreakState,
 } from './poolBreakPhysics.js'
 
@@ -45,4 +47,25 @@ test( 'the cinematic timeline keeps the existing exit fade timing', () =>
 
   assert.equal( sampleCinematicBreakState( 0.76, simulation ).opacity, 1 )
   assert.equal( sampleCinematicBreakState( 0.9, simulation ).opacity, 0 )
+} )
+
+
+test( 'Draft 2 maps the deterministic spread to a short, reversible handoff', () =>
+{
+  const simulation = getBreakSimulation()
+  const readyState = sampleDraft2BreakState( DRAFT2_TIMING_CONTRACT.transitionReady, simulation )
+  const milestoneFrame = simulation.frames[ simulation.milestones.transitionReadyFrame ]
+  const afterReadyState = sampleDraft2BreakState( DRAFT2_TIMING_CONTRACT.transitionReady + 0.001, simulation )
+  const handoffState = sampleDraft2BreakState( DRAFT2_TIMING_CONTRACT.studioHandoff, simulation )
+
+  assert.equal( readyState.phase, 'break' )
+  assert.equal( readyState.opacity, 1 )
+  assert.deepEqual(
+    readyState.balls.map( ( ball ) => ball.position ),
+    milestoneFrame.balls.map( ( ball ) => ball.position ),
+  )
+  assert.equal( afterReadyState.phase, 'exit' )
+  assert.ok( afterReadyState.opacity < 1 )
+  assert.equal( handoffState.opacity, 0 )
+  assert.deepEqual( handoffState.balls, readyState.balls )
 } )

--- a/tests/browser/draft2-benchmark.spec.js
+++ b/tests/browser/draft2-benchmark.spec.js
@@ -207,6 +207,9 @@ const installGestureProbe = async ( page ) =>
       wheelCount: 0,
       forwardWheelCount: 0,
       reverseWheelCount: 0,
+      touchStartCount: 0,
+      touchMoveCount: 0,
+      touchEndCount: 0,
     }
 
     // Count browser input at the document boundary so a handoff cannot pass by
@@ -217,6 +220,11 @@ const installGestureProbe = async ( page ) =>
       if ( event.deltaY > 0 ) state.forwardWheelCount += 1
       if ( event.deltaY < 0 ) state.reverseWheelCount += 1
     }, { capture: true, passive: true } )
+
+    // Touch counters prove the portrait path used a real touch sequence when the browser supports CDP input.
+    window.addEventListener( "touchstart", () => { state.touchStartCount += 1 }, { capture: true, passive: true } )
+    window.addEventListener( "touchmove", () => { state.touchMoveCount += 1 }, { capture: true, passive: true } )
+    window.addEventListener( "touchend", () => { state.touchEndCount += 1 }, { capture: true, passive: true } )
 
     window.__draft2GestureProbe = {
       snapshot: () => ( { ...state } ),
@@ -261,8 +269,39 @@ const getBoundedSoftGestureDelta = ( page ) => page.evaluate( () =>
   return Math.ceil( range * 0.9 )
 } )
 
+const dispatchPortraitTouchGesture = async ( context ) =>
+{
+  const client = await context.newCDPSession( await context.pages()[ 0 ] )
+  const touchPoint = ( y ) => ( {
+    x: 195,
+    y,
+    radiusX: 1,
+    radiusY: 1,
+    force: 1,
+    id: 1,
+  } )
+
+  await client.send( 'Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [ touchPoint( 840 ) ],
+    modifiers: 0,
+  } )
+  await client.send( 'Input.dispatchTouchEvent', {
+    type: 'touchMove',
+    touchPoints: [ touchPoint( 700 ) ],
+    modifiers: 0,
+  } )
+  await client.send( 'Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+    modifiers: 0,
+  } )
+}
+
 const waitForStudioHandoff = async ( page ) =>
 {
+  const startedAt = Date.now()
+  const completionBudgetMs = 2_500
   await expect( page.getByRole( 'button', { name: 'Go to Studio page' } ) )
     .toHaveAttribute( 'aria-current', 'page', { timeout: 10_000 } )
   await expect( page.locator( '.title-screen' ) ).toBeVisible()
@@ -270,6 +309,8 @@ const waitForStudioHandoff = async ( page ) =>
   await expect.poll( async () => page.locator( '.draft-layer-webgl' ).getAttribute( 'data-webgl-progress' ), {
     timeout: 10_000,
   } ).toBe( '1.0000' )
+  await expect( page.locator( '.webgl-pool-canvas' ) ).toHaveCSS( 'opacity', '0' )
+  expect( Date.now() - startedAt ).toBeLessThan( completionBudgetMs )
 }
 
 for ( const viewport of VIEWPORTS )
@@ -321,6 +362,37 @@ for ( const viewport of VIEWPORTS )
     }
   } )
 }
+
+test( 'Draft 2 touch gesture reaches Studio on portrait', async ( { browser, baseURL } ) =>
+{
+  const context = await browser.newContext( {
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 1,
+    hasTouch: true,
+    isMobile: true,
+  } )
+  const page = await context.newPage()
+
+  try
+  {
+    await installGestureProbe( page )
+    await page.goto( `${baseURL}/?draft=webgl&benchmark=draft2`, { waitUntil: 'domcontentloaded' } )
+    await waitForDraftTwo( page )
+    await driveStoryProgress( page, 0.22 )
+    await dispatchPortraitTouchGesture( context )
+    await waitForStudioHandoff( page )
+
+    const gesture = await page.evaluate( () => window.__draft2GestureProbe.snapshot() )
+    expect( gesture.wheelCount ).toBe( 0 )
+    expect( gesture.touchStartCount ).toBe( 1 )
+    expect( gesture.touchMoveCount ).toBeGreaterThan( 0 )
+    expect( gesture.touchEndCount ).toBe( 1 )
+  }
+  finally
+  {
+    await context.close()
+  }
+} )
 
 test( 'Draft 2 one soft gesture respects reduced motion', async ( { browser, baseURL } ) =>
 {

--- a/tests/browser/draft2-benchmark.spec.js
+++ b/tests/browser/draft2-benchmark.spec.js
@@ -301,7 +301,7 @@ const dispatchPortraitTouchGesture = async ( context ) =>
 const waitForStudioHandoff = async ( page ) =>
 {
   const startedAt = Date.now()
-  const completionBudgetMs = 2_500
+  const completionBudgetMs = 1_200
   await expect( page.getByRole( 'button', { name: 'Go to Studio page' } ) )
     .toHaveAttribute( 'aria-current', 'page', { timeout: 10_000 } )
   await expect( page.locator( '.title-screen' ) ).toBeVisible()
@@ -342,7 +342,7 @@ for ( const viewport of VIEWPORTS )
       expect( gesture.wheelCount ).toBe( 1 )
       expect( gesture.forwardWheelCount ).toBe( 1 )
       expect( phaseTrace.phases ).toContain( 'BREAK  /  RUN' )
-      expect( phaseTrace.phases ).toContain( 'POCKET  /  CLEAR' )
+      // The faster Draft 2 path intentionally cuts past the old pocket phase.
       expect( phaseTrace.phases ).toContain( 'STUDIO  /  CUT' )
 
       // A reverse gesture after the handoff must remain authoritative; the
@@ -387,6 +387,35 @@ test( 'Draft 2 touch gesture reaches Studio on portrait', async ( { browser, bas
     expect( gesture.touchStartCount ).toBe( 1 )
     expect( gesture.touchMoveCount ).toBeGreaterThan( 0 )
     expect( gesture.touchEndCount ).toBe( 1 )
+  }
+  finally
+  {
+    await context.close()
+  }
+} )
+
+test( 'Draft 2 cuts the pocket drop before the Studio crossfade', async ( { browser, baseURL } ) =>
+{
+  const context = await browser.newContext( {
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 1,
+  } )
+  const page = await context.newPage()
+
+  try
+  {
+    await page.goto( `${baseURL}/?draft=webgl&benchmark=draft2`, { waitUntil: 'domcontentloaded' } )
+    await waitForDraftTwo( page )
+    await driveStoryProgress( page, 0.215 )
+
+    const ballOpacity = await page.locator( '.ball-rig' ).evaluate( ( node ) => getComputedStyle( node ).opacity )
+    const pocketOpacity = await page.locator( '.pocket-iris' ).evaluate( ( node ) => getComputedStyle( node ).opacity )
+    const titleOpacity = await page.locator( '.title-screen' ).evaluate( ( node ) => getComputedStyle( node ).opacity )
+
+    // The 8-ball and pocket mask are already cut while the next-page title has not started fading in.
+    expect( ballOpacity ).toBe( '0' )
+    expect( pocketOpacity ).toBe( '0' )
+    expect( titleOpacity ).toBe( '0' )
   }
   finally
   {

--- a/tests/browser/draft2-benchmark.spec.js
+++ b/tests/browser/draft2-benchmark.spec.js
@@ -198,6 +198,179 @@ const waitForDraftTwo = async ( page ) =>
   } )
 }
 
+
+const installGestureProbe = async ( page ) =>
+{
+  await page.addInitScript( () =>
+  {
+    const state = {
+      wheelCount: 0,
+      forwardWheelCount: 0,
+      reverseWheelCount: 0,
+    }
+
+    // Count browser input at the document boundary so a handoff cannot pass by
+    // silently consuming a second wheel event inside the scene.
+    window.addEventListener( 'wheel', ( event ) =>
+    {
+      state.wheelCount += 1
+      if ( event.deltaY > 0 ) state.forwardWheelCount += 1
+      if ( event.deltaY < 0 ) state.reverseWheelCount += 1
+    }, { capture: true, passive: true } )
+
+    window.__draft2GestureProbe = {
+      snapshot: () => ( { ...state } ),
+    }
+  } )
+}
+
+const installPhaseProbe = async ( page ) =>
+{
+  await page.evaluate( () =>
+  {
+    const phase = document.querySelector( '.webgl-phase' )
+    if ( !phase ) throw new Error( 'Draft 2 phase label is not available.' )
+
+    const phases = []
+    const recordPhase = () =>
+    {
+      const value = phase.textContent?.trim()
+      if ( value && phases[ phases.length - 1 ] !== value ) phases.push( value )
+    }
+
+    recordPhase()
+    const observer = new MutationObserver( recordPhase )
+    observer.observe( phase, { childList: true, characterData: true, subtree: true } )
+
+    // Keep the observer behind a small public test seam; no Three.js objects or
+    // private tween state are exposed to the browser assertion.
+    window.__draft2PhaseProbe = {
+      snapshot: () => ( { phases: [ ...phases ] } ),
+      stop: () => observer.disconnect(),
+    }
+  } )
+}
+
+const getBoundedSoftGestureDelta = ( page ) => page.evaluate( () =>
+{
+  const story = document.querySelector( '.story' )
+  const range = story ? Math.max( 0, story.offsetHeight - window.innerHeight ) : 0
+
+  // A single bounded wheel packet crosses the intro weighting on both target
+  // viewports while remaining below one full story range.
+  return Math.ceil( range * 0.9 )
+} )
+
+const waitForStudioHandoff = async ( page ) =>
+{
+  await expect( page.getByRole( 'button', { name: 'Go to Studio page' } ) )
+    .toHaveAttribute( 'aria-current', 'page', { timeout: 10_000 } )
+  await expect( page.locator( '.title-screen' ) ).toBeVisible()
+  await expect( page.locator( '.scene-interface' ) ).toBeHidden()
+  await expect.poll( async () => page.locator( '.draft-layer-webgl' ).getAttribute( 'data-webgl-progress' ), {
+    timeout: 10_000,
+  } ).toBe( '1.0000' )
+}
+
+for ( const viewport of VIEWPORTS )
+{
+  test( `Draft 2 one soft gesture reaches Studio — ${viewport.name}`, async ( { browser, baseURL } ) =>
+  {
+    const context = await browser.newContext( {
+      viewport: { width: viewport.width, height: viewport.height },
+      deviceScaleFactor: 1,
+    } )
+    const page = await context.newPage()
+
+    try
+    {
+      await installGestureProbe( page )
+      await page.goto( `${baseURL}/?draft=webgl&benchmark=draft2`, { waitUntil: 'domcontentloaded' } )
+      await waitForDraftTwo( page )
+      await installPhaseProbe( page )
+      await page.mouse.move( viewport.width / 2, viewport.height / 2 )
+
+      // One bounded wheel packet is the complete visitor gesture. No follow-up
+      // nudge is allowed after the rack reaches its readable spread.
+      const gestureDelta = await getBoundedSoftGestureDelta( page )
+      await page.mouse.wheel( 0, gestureDelta )
+      await waitForStudioHandoff( page )
+
+      const gesture = await page.evaluate( () => window.__draft2GestureProbe.snapshot() )
+      const phaseTrace = await page.evaluate( () => window.__draft2PhaseProbe.snapshot() )
+      expect( gesture.wheelCount ).toBe( 1 )
+      expect( gesture.forwardWheelCount ).toBe( 1 )
+      expect( phaseTrace.phases ).toContain( 'BREAK  /  RUN' )
+      expect( phaseTrace.phases ).toContain( 'POCKET  /  CLEAR' )
+      expect( phaseTrace.phases ).toContain( 'STUDIO  /  CUT' )
+
+      // A reverse gesture after the handoff must remain authoritative; the
+      // shortened transition must not leave Lenis locked at the page boundary.
+      await page.mouse.wheel( 0, -Math.ceil( gestureDelta * 0.2 ) )
+      await expect.poll( async () => Number(
+        await page.locator( '.draft-layer-webgl' ).getAttribute( 'data-webgl-progress' ),
+      ) ).toBeLessThan( 1 )
+      const reversedGesture = await page.evaluate( () => window.__draft2GestureProbe.snapshot() )
+      expect( reversedGesture.forwardWheelCount ).toBe( 1 )
+      expect( reversedGesture.reverseWheelCount ).toBe( 1 )
+    }
+    finally
+    {
+      await page.evaluate( () => window.__draft2PhaseProbe?.stop() ).catch( () => {} )
+      await context.close()
+    }
+  } )
+}
+
+test( 'Draft 2 one soft gesture respects reduced motion', async ( { browser, baseURL } ) =>
+{
+  const context = await browser.newContext( {
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 1,
+    reducedMotion: 'reduce',
+  } )
+  const page = await context.newPage()
+
+  try
+  {
+    await installGestureProbe( page )
+    await page.goto( `${baseURL}/?draft=webgl&benchmark=draft2`, { waitUntil: 'domcontentloaded' } )
+    await waitForDraftTwo( page )
+    await page.mouse.move( 195, 422 )
+    await page.mouse.wheel( 0, await getBoundedSoftGestureDelta( page ) )
+    await waitForStudioHandoff( page )
+
+    const gesture = await page.evaluate( () => window.__draft2GestureProbe.snapshot() )
+    expect( gesture.wheelCount ).toBe( 1 )
+    expect( gesture.forwardWheelCount ).toBe( 1 )
+  }
+  finally
+  {
+    await context.close()
+  }
+} )
+
+test( 'Draft 2 page controls remain keyboard reachable', async ( { browser, baseURL } ) =>
+{
+  const context = await browser.newContext( { viewport: { width: 1280, height: 800 } } )
+  const page = await context.newPage()
+
+  try
+  {
+    await page.goto( `${baseURL}/?draft=webgl&benchmark=draft2`, { waitUntil: 'domcontentloaded' } )
+    await waitForDraftTwo( page )
+    const studioButton = page.getByRole( 'button', { name: 'Go to Studio page' } )
+    await studioButton.focus()
+    await page.keyboard.press( 'Enter' )
+    await expect( studioButton ).toHaveAttribute( 'aria-current', 'page' )
+    await expect( page.locator( '.title-screen' ) ).toBeVisible()
+  }
+  finally
+  {
+    await context.close()
+  }
+} )
+
 const driveStoryProgress = async ( page, progress ) =>
 {
   const target = await page.evaluate( ( nextProgress ) =>


### PR DESCRIPTION
## Summary

Implements the approved soft-swipe transition spec in #10.

- Compress Draft 2's post-impact scatter/exit timing.
- Complete the Studio handoff from the same qualifying forward gesture.
- Keep page state, reverse input, reduced motion, and navigation synchronized.
- Add browser regression coverage for the one-gesture behavior.

Closes #10
Closes #11
Closes #12
Closes #13
Closes #14

Depends on #9 for the current Draft 2 performance baseline.
